### PR TITLE
Custom src

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(uv_mbed_sources
         src/bio.c
         src/engine_mbedtls.c
         src/http.c
+        src/tcp_src.c
         src/um_debug.c
         src/um_debug.h
         )

--- a/include/uv_mbed/tcp_src.h
+++ b/include/uv_mbed/tcp_src.h
@@ -1,0 +1,52 @@
+/*
+Copyright 2019-2020 NetFoundry, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file tcp_src.h
+ * @brief header file for tcp_src, which can be used as a source link in um_http requests
+ *
+ */
+
+#ifndef UV_MBED_TCP_SRC_H
+#define UV_MBED_TCP_SRC_H
+
+#include "um_http_src_t.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Inherits from um_http_source_t and is used to register source link for `um_http`.
+ */
+typedef struct tcp_src_s {
+    UM_HTTP_SRC_FIELDS
+    uv_tcp_t conn;
+} tcp_src_t;
+
+/**
+ * Initialize a `tcp_src_t` handle
+ * 
+ * @param l the uv loop
+ * @param tl the tcp_src link to initialize
+ */
+int tcp_src_init(uv_loop_t *l, tcp_src_t *tl);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //UV_MBED_TCP_SRC_H

--- a/include/uv_mbed/um_http.h
+++ b/include/uv_mbed/um_http.h
@@ -52,6 +52,7 @@ typedef LIST_HEAD(hdr_list, um_http_hdr_s) um_header_list;
 
 typedef struct um_http_resp_s um_http_resp_t;
 typedef struct um_http_req_s um_http_req_t;
+typedef struct um_http_s um_http_t;
 
 /**
  * HTTP response callback type.
@@ -120,6 +121,16 @@ typedef struct um_http_req_s {
 } um_http_req_t;
 
 /**
+ * Custom source link connect callback type
+ */
+typedef void (*um_http_custom_connect_cb)(um_http_t *c, int status);
+
+/**
+ * Custom source link connect method type
+ */
+typedef int (*um_http_custom_connect_t)(uv_loop_t *l, um_http_t *c, um_http_custom_connect_cb cb);
+
+/**
  * @brief HTTP client struct
  */
 typedef struct um_http_s {
@@ -135,6 +146,9 @@ typedef struct um_http_s {
     int connected;
     uv_tcp_t conn;
     uv_link_source_t conn_src;
+    uv_link_t *custom_src;
+    um_http_custom_connect_t custom_connect;
+
     uv_link_t http_link;
     uv_link_t tls_link;
 
@@ -180,7 +194,14 @@ int um_http_idle_keepalive(um_http_t *clt, long millis);
 void um_http_set_ssl(um_http_t *clt, tls_context *tls);
 
 /**
- * \brief Set header on the client.
+ *  @brief Set custom source link
+ * 
+ *  Set a source link that will be used in place of TCP link ssource
+ */
+void um_http_set_link_source(um_http_t *clt, uv_link_t *src, um_http_custom_connect_t connect);
+
+/**
+ * @brief Set header on the client.
  *
  * All requests execute by the client will get that request header. Pass `value==NULL` to unset the header.
  * @param clt

--- a/include/uv_mbed/um_http.h
+++ b/include/uv_mbed/um_http.h
@@ -131,6 +131,11 @@ typedef void (*um_http_custom_connect_cb)(um_http_t *c, int status);
 typedef int (*um_http_custom_connect_t)(um_http_t *c, um_http_custom_connect_cb cb);
 
 /**
+ *  Release resources associated with custom source link on `um_http_close()`
+ */
+typedef void (*um_http_close_cb)(uv_link_t *l);
+
+/**
  * @brief HTTP client struct
  */
 typedef struct um_http_s {
@@ -146,8 +151,10 @@ typedef struct um_http_s {
     int connected;
     uv_tcp_t conn;
     uv_link_source_t conn_src;
+
     uv_link_t *custom_src;
     um_http_custom_connect_t custom_connect;
+    um_http_close_cb custom_link_release;
 
     uv_link_t http_link;
     uv_link_t tls_link;
@@ -198,7 +205,7 @@ void um_http_set_ssl(um_http_t *clt, tls_context *tls);
  * 
  *  Set a source link that will be used in place of TCP link source
  */
-void um_http_set_link_source(um_http_t *clt, uv_link_t *src, um_http_custom_connect_t connect);
+void um_http_set_link_source(um_http_t *clt, uv_link_t *src, um_http_custom_connect_t c, um_http_close_cb rcb);
 
 /**
  * @brief Set header on the client.

--- a/include/uv_mbed/um_http.h
+++ b/include/uv_mbed/um_http.h
@@ -196,7 +196,7 @@ void um_http_set_ssl(um_http_t *clt, tls_context *tls);
 /**
  *  @brief Set custom source link
  * 
- *  Set a source link that will be used in place of TCP link ssource
+ *  Set a source link that will be used in place of TCP link source
  */
 void um_http_set_link_source(um_http_t *clt, uv_link_t *src, um_http_custom_connect_t connect);
 

--- a/include/uv_mbed/um_http.h
+++ b/include/uv_mbed/um_http.h
@@ -128,7 +128,7 @@ typedef void (*um_http_custom_connect_cb)(um_http_t *c, int status);
 /**
  * Custom source link connect method type
  */
-typedef int (*um_http_custom_connect_t)(uv_loop_t *l, um_http_t *c, um_http_custom_connect_cb cb);
+typedef int (*um_http_custom_connect_t)(um_http_t *c, um_http_custom_connect_cb cb);
 
 /**
  * @brief HTTP client struct

--- a/include/uv_mbed/um_http_src_t.h
+++ b/include/uv_mbed/um_http_src_t.h
@@ -1,0 +1,60 @@
+/*
+Copyright 2019-2020 NetFoundry, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @file um_http_src_t.h
+ * @brief header file for um_http_src_t type
+ *
+ */
+
+#ifndef UM_HTTP_SRC_T_H
+#define UM_HTTP_SRC_T_H
+
+#include <uv_link_t.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// forward ref
+typedef struct um_http_s um_http_t;
+
+/**
+ * Source link types
+ */
+typedef struct um_http_src_s um_http_src_t;
+
+typedef void (*um_http_src_connect_cb)(um_http_src_t *sl, int status);
+typedef  int (*um_http_src_connect_t)(um_http_src_t *sl, um_http_src_connect_cb cb);
+typedef void (*um_http_src_release_t)(um_http_src_t *sl);
+
+#define UM_HTTP_SRC_FIELDS                  \
+    uv_link_t *link;                        \
+    uv_loop_t *loop;                        \
+    um_http_src_connect_t connect;          \
+    um_http_src_connect_cb connect_cb;      \
+    um_http_src_release_t release;          \
+    um_http_t *clt;                         \
+
+typedef struct um_http_src_s {
+    UM_HTTP_SRC_FIELDS
+} um_http_src_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //UM_HTTP_SRC_T_H

--- a/src/http.c
+++ b/src/http.c
@@ -557,6 +557,10 @@ int um_http_close(um_http_t *clt) {
     uv_close((uv_handle_t *) &clt->idle_timer, NULL);
     uv_close((uv_handle_t *) &clt->proc, NULL);
 
+    if (clt->custom_src != NULL) {
+        clt->custom_link_release(clt->custom_src);
+    }
+
     free_http(clt);
     return 0;
 }
@@ -635,10 +639,10 @@ void um_http_set_ssl(um_http_t *clt, tls_context *tls) {
     clt->tls = tls;
 }
 
-void um_http_set_link_source(um_http_t *clt, uv_link_t *src, um_http_custom_connect_t connect) {
-    UM_LOG(DEBG, "setting custom link sourcce");
+void um_http_set_link_source(um_http_t *clt, uv_link_t *src, um_http_custom_connect_t connect, um_http_close_cb ccb) {
     clt->custom_src = src;
     clt->custom_connect = connect;
+    clt->custom_link_release = ccb;
 }
 
 um_http_req_t *um_http_req(um_http_t *c, const char *method, const char *path, um_http_resp_cb resp_cb, void *ctx) {

--- a/src/http.c
+++ b/src/http.c
@@ -481,8 +481,9 @@ static void process_requests(uv_async_t *ar) {
         UM_LOG(VERB, "client not connected, starting connect sequence");
         if (c->custom_src != NULL) {
             UM_LOG(VERB, "custom src found, calling custom connect");
-            c->custom_connect(ar->loop, c, custom_connect_cb);
-        } else {
+            c->custom_connect(c, custom_connect_cb);
+        } 
+        else {
             uv_getaddrinfo_t *resolv_req = malloc(sizeof(uv_getaddrinfo_t));
             resolv_req->data = c;
             uv_getaddrinfo(ar->loop, resolv_req, resolve_cb, c->host, c->port, NULL);

--- a/src/http.c
+++ b/src/http.c
@@ -574,6 +574,7 @@ int um_http_init(uv_loop_t *l, um_http_t *clt, const char *url) {
     clt->engine = NULL;
     clt->active = NULL;
     clt->connected = Disconnected;
+    clt->custom_src = NULL;
 
     clt->idle_time = DEFAULT_IDLE_TIMEOUT;
     uv_timer_init(l, &clt->idle_timer);

--- a/src/tcp_src.c
+++ b/src/tcp_src.c
@@ -1,0 +1,76 @@
+/*
+Copyright 2019-2020 NetFoundry, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "uv_mbed/um_http.h"
+#include "uv_mbed/tcp_src.h"
+#include "um_debug.h"
+
+// connect and release method for um_http custom source link
+static int tcp_src_connect(um_http_src_t *sl, um_http_src_connect_cb cb);
+static void tcp_src_release(um_http_src_t *sl);
+
+int tcp_src_init(uv_loop_t *l, tcp_src_t *tl) {
+    tl->loop = l;
+    tl->clt = NULL;
+    tl->link = malloc(sizeof(uv_link_source_t));
+    tl->connect = tcp_src_connect;
+    tl->connect_cb = NULL;
+    tl->release = tcp_src_release;
+
+    return 0;
+}
+
+static void tcp_connect_cb(uv_connect_t *req, int status) {
+    tcp_src_t *sl = req->data;
+
+    UM_LOG(VERB, "connected status = %d", status);
+    if (status == 0) {
+        uv_link_source_init((uv_link_source_t *)sl->link, (uv_stream_t *) &sl->conn);
+    }
+    
+    sl->connect_cb((um_http_src_t *)sl, status);
+    free(req);
+}
+
+static void resolve_cb(uv_getaddrinfo_t *req, int status, struct addrinfo *addr) {
+    tcp_src_t *sl = req->data;
+
+    UM_LOG(VERB, "resolved status = %d", status);
+    if (status == 0) {
+        uv_connect_t *conn_req = malloc(sizeof(uv_connect_t));
+        conn_req->data = sl;
+        uv_tcp_init(sl->loop, &sl->conn);
+        uv_tcp_connect(conn_req, &sl->conn, addr->ai_addr, tcp_connect_cb);
+        uv_freeaddrinfo(addr);
+    } else {
+        sl->connect_cb((um_http_src_t *)sl, status);
+    }
+    free(req);
+}
+
+static int tcp_src_connect(um_http_src_t *sl, um_http_src_connect_cb cb) {
+    uv_getaddrinfo_t *resolv_req = malloc(sizeof(uv_getaddrinfo_t));
+
+    sl->connect_cb = cb;
+    resolv_req->data = sl;
+    uv_getaddrinfo(sl->loop, resolv_req, resolve_cb, sl->clt->host, sl->clt->port, NULL);
+
+    return 0;
+}
+
+static void tcp_src_release(um_http_src_t *sl) {
+    free(sl->link);
+}


### PR DESCRIPTION
Added ability to add a custom uv_link_t to be used as the source of the chain in place of tcp uv_link_source_t.  Used in ziti-sdk-c to create a link source that sends the http/https traffic over Ziti.