### PR TITLE
linux embedded (openwrt) compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ add_library(uv_mbed STATIC
         ${p11_sources}
         )
 
+set_property(TARGET uv_mbed PROPERTY C_STANDARD 99)
+
 target_include_directories(uv_mbed
         PUBLIC
         $<INSTALL_INTERFACE:include>

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -10,6 +10,8 @@ set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
 add_subdirectory(libuv)
 set_target_properties(uv_a PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/libuv/include)
+set_target_properties(uv PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/libuv/include)
 
 add_library(http-parser STATIC http-parser/http_parser.c)
 target_include_directories(http-parser PUBLIC http-parser)


### PR DESCRIPTION
- revert to libuv version v1.34.2: `dup3()` is not available on some embedded systems
- set C standard