### PR TITLE
rename um_http_src* => um_src*

### DIFF
--- a/include/uv_mbed/tcp_src.h
+++ b/include/uv_mbed/tcp_src.h
@@ -33,7 +33,7 @@ extern "C" {
  * Inherits from um_http_source_t and is used to register source link for `um_http`.
  */
 typedef struct tcp_src_s {
-    UM_HTTP_SRC_FIELDS
+    UM_SRC_FIELDS
     uv_tcp_t conn;
 } tcp_src_t;
 

--- a/include/uv_mbed/um_http.h
+++ b/include/uv_mbed/um_http.h
@@ -137,7 +137,7 @@ typedef struct um_http_s {
     um_header_list headers;
 
     int connected;
-    um_http_src_t *src;
+    um_src_t *src;
     tcp_src_t default_src;
 
     uv_link_t http_link;
@@ -173,7 +173,7 @@ int um_http_init(uv_loop_t *l, um_http_t *clt, const char *url);
  * 
  * @return 0 or error code
  */
-int um_http_init_with_src(uv_loop_t *l, um_http_t *clt, const char *url, um_http_src_t *src);
+int um_http_init_with_src(uv_loop_t *l, um_http_t *clt, const char *url, um_src_t *src);
 
 /**
  * \brief Set idle timeout.

--- a/include/uv_mbed/um_http_src_t.h
+++ b/include/uv_mbed/um_http_src_t.h
@@ -35,26 +35,26 @@ typedef struct um_http_s um_http_t;
 /**
  * Source link types
  */
-typedef struct um_http_src_s um_http_src_t;
+typedef struct um_src_s um_src_t;
 
-typedef void (*um_http_src_connect_cb)(um_http_src_t *sl, int status, void *connect_ctx);
-typedef void (*um_http_src_cancel_t)(um_http_src_t *sl);
-typedef  int (*um_http_src_connect_t)(um_http_src_t *sl, const char *host, const char *port, um_http_src_connect_cb cb, void *connect_ctx);
-typedef void (*um_http_src_release_t)(um_http_src_t *sl);
+typedef void (*um_src_connect_cb)(um_src_t *sl, int status, void *connect_ctx);
+typedef void (*um_src_cancel_t)(um_src_t *sl);
+typedef  int (*um_src_connect_t)(um_src_t *sl, const char *host, const char *port, um_src_connect_cb cb, void *connect_ctx);
+typedef void (*um_src_release_t)(um_src_t *sl);
 
-#define UM_HTTP_SRC_FIELDS                  \
+#define UM_SRC_FIELDS                       \
     uv_link_t *link;                        \
     uv_loop_t *loop;                        \
     void *connect_ctx;                      \
-    um_http_src_connect_t connect;          \
-    um_http_src_connect_cb connect_cb;      \
-    um_http_src_cancel_t cancel;            \
-    um_http_src_release_t release;          \
+    um_src_connect_t connect;          \
+    um_src_connect_cb connect_cb;      \
+    um_src_cancel_t cancel;            \
+    um_src_release_t release;          \
 
 
-typedef struct um_http_src_s {
-    UM_HTTP_SRC_FIELDS
-} um_http_src_t;
+typedef struct um_src_s {
+    UM_SRC_FIELDS
+} um_src_t;
 
 #ifdef __cplusplus
 }

--- a/include/uv_mbed/um_websocket.h
+++ b/include/uv_mbed/um_websocket.h
@@ -40,7 +40,7 @@ struct um_websocket_s {
 
     uv_connect_t *conn_req;
 
-    um_http_src_t *src;
+    um_src_t *src;
     tcp_src_t default_src;
 
     uv_link_t ws_link;
@@ -58,7 +58,7 @@ struct um_websocket_s {
  */
 int um_websocket_init(uv_loop_t *loop, um_websocket_t *ws);
 
-int um_websocket_init_with_src (uv_loop_t *loop, um_websocket_t *ws, um_http_src_t *src);
+int um_websocket_init_with_src (uv_loop_t *loop, um_websocket_t *ws, um_src_t *src);
 
 /**
  * @brief set #tls_context on the client.

--- a/src/http.c
+++ b/src/http.c
@@ -191,7 +191,7 @@ static void link_close_cb(uv_link_t *l) {
     }
 }
 
-static void src_connect_cb(um_http_src_t *src, int status, void *ctx) {
+static void src_connect_cb(um_src_t *src, int status, void *ctx) {
     UM_LOG(VERB, "src connected status = %d", status);
     um_http_t *clt = ctx;
     if (status == 0) {
@@ -363,7 +363,7 @@ int um_http_close(um_http_t *clt) {
     return 0;
 }
 
-int um_http_init_with_src(uv_loop_t *l, um_http_t *clt, const char *url, um_http_src_t *src) {
+int um_http_init_with_src(uv_loop_t *l, um_http_t *clt, const char *url, um_src_t *src) {
     STAILQ_INIT(&clt->requests);
     LIST_INIT(&clt->headers);
 
@@ -433,7 +433,7 @@ int um_http_init_with_src(uv_loop_t *l, um_http_t *clt, const char *url, um_http
 
 int um_http_init(uv_loop_t *l, um_http_t *clt, const char *url) {
     tcp_src_init(l, &clt->default_src);
-    return um_http_init_with_src(l, clt, url, (um_http_src_t *)&clt->default_src);    
+    return um_http_init_with_src(l, clt, url, (um_src_t *)&clt->default_src);
 }
 int um_http_connect_timeout(um_http_t *clt, long millis) {
     clt->connect_timeout = millis;

--- a/src/tcp_src.c
+++ b/src/tcp_src.c
@@ -19,9 +19,9 @@ limitations under the License.
 #include "um_debug.h"
 
 // connect and release method for um_http custom source link
-static int tcp_src_connect(um_http_src_t *sl, const char *host, const char *service, um_http_src_connect_cb cb, void *ctx);
-static void tcp_src_release(um_http_src_t *sl);
-static void tcp_src_cancel(um_http_src_t *sl);
+static int tcp_src_connect(um_src_t *sl, const char *host, const char *service, um_src_connect_cb cb, void *ctx);
+static void tcp_src_release(um_src_t *sl);
+static void tcp_src_cancel(um_src_t *sl);
 
 int tcp_src_init(uv_loop_t *l, tcp_src_t *tl) {
     tl->loop = l;
@@ -42,7 +42,7 @@ static void tcp_connect_cb(uv_connect_t *req, int status) {
         uv_link_source_init((uv_link_source_t *)sl->link, (uv_stream_t *) &sl->conn);
     }
     
-    sl->connect_cb((um_http_src_t *)sl, status, sl->connect_ctx);
+    sl->connect_cb((um_src_t *)sl, status, sl->connect_ctx);
     free(req);
 }
 
@@ -57,12 +57,12 @@ static void resolve_cb(uv_getaddrinfo_t *req, int status, struct addrinfo *addr)
         uv_tcp_connect(conn_req, &sl->conn, addr->ai_addr, tcp_connect_cb);
         uv_freeaddrinfo(addr);
     } else {
-        sl->connect_cb((um_http_src_t *)sl, status, sl->connect_ctx);
+        sl->connect_cb((um_src_t *)sl, status, sl->connect_ctx);
     }
     free(req);
 }
 
-static int tcp_src_connect(um_http_src_t *sl, const char* host, const char *service, um_http_src_connect_cb cb, void *ctx) {
+static int tcp_src_connect(um_src_t *sl, const char* host, const char *service, um_src_connect_cb cb, void *ctx) {
     uv_getaddrinfo_t *resolv_req = malloc(sizeof(uv_getaddrinfo_t));
 
     sl->connect_cb = cb;
@@ -73,12 +73,12 @@ static int tcp_src_connect(um_http_src_t *sl, const char* host, const char *serv
     return 0;
 }
 
-static void tcp_src_cancel(um_http_src_t *sl) {
+static void tcp_src_cancel(um_src_t *sl) {
     tcp_src_t *tl = (tcp_src_t*)sl;
     uv_close((uv_handle_t *) &tl->conn, NULL);
 }
 
-static void tcp_src_release(um_http_src_t *sl) {
+static void tcp_src_release(um_src_t *sl) {
     free(sl->link);
     sl->link = NULL;
 }

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -46,7 +46,7 @@ typedef struct ws_write_s {
 
 extern tls_context *get_default_tls();
 
-static void src_connect_cb(um_http_src_t *sl, int status, void *connect_ctx);
+static void src_connect_cb(um_src_t *sl, int status, void *connect_ctx);
 static void ws_read_cb(uv_link_t* link,
                                 ssize_t nread,
                                 const uv_buf_t* buf);
@@ -65,7 +65,7 @@ static const uv_link_methods_t ws_methods = {
 };
 
 
-int um_websocket_init_with_src (uv_loop_t *loop, um_websocket_t *ws, um_http_src_t *src) {
+int um_websocket_init_with_src (uv_loop_t *loop, um_websocket_t *ws, um_src_t *src) {
     ws->loop = loop;
     ws->type = UV_IDLE;
     ws->src = src;
@@ -102,7 +102,7 @@ int um_websocket_init_with_src (uv_loop_t *loop, um_websocket_t *ws, um_http_src
 int um_websocket_init(uv_loop_t *loop, um_websocket_t *ws) {
     memset(ws, 0, sizeof(um_websocket_t));
     tcp_src_init(loop, &ws->default_src);
-    return um_websocket_init_with_src(loop, ws, (um_http_src_t *) &ws->default_src);
+    return um_websocket_init_with_src(loop, ws, (um_src_t *) &ws->default_src);
 }
 
 void um_websocket_set_header(um_websocket_t *ws, const char *header, const char *value) {
@@ -243,7 +243,7 @@ int um_websocket_write(uv_write_t *req, um_websocket_t *ws, uv_buf_t *buf, uv_wr
 }
 
 
-static void src_connect_cb(um_http_src_t *sl, int status, void *connect_ctx) {
+static void src_connect_cb(um_src_t *sl, int status, void *connect_ctx) {
     UM_LOG(DEBG, "connect rc = %d", status);
     uv_connect_t *req = connect_ctx;
     um_websocket_t *ws = (um_websocket_t *) req->handle;


### PR DESCRIPTION
Purely cosmetic change to signify a more generic (than just http) nature of `um_src_` types