### PR TITLE
Better handle TLS link state

### DIFF
--- a/include/uv_mbed/tls_engine.h
+++ b/include/uv_mbed/tls_engine.h
@@ -29,6 +29,7 @@ extern "C" {
 #endif
 
 typedef enum tls_handshake_st {
+    TLS_HS_BEFORE,
     TLS_HS_CONTINUE,
     TLS_HS_COMPLETE,
     TLS_HS_ERROR

--- a/include/uv_mbed/tls_link.h
+++ b/include/uv_mbed/tls_link.h
@@ -26,7 +26,6 @@ struct tls_link_s {
 
     tls_engine *engine;
     tls_handshake_cb hs_cb;
-    int state;
 };
 
 

--- a/sample/common.c
+++ b/sample/common.c
@@ -17,6 +17,10 @@ limitations under the License.
 
 #include "common.h"
 
+void logger(int level, const char *file, unsigned int line, const char *msg) {
+    fprintf(stderr, "%s:%d %s\n", file, line, msg);
+}
+
 void resp_cb(um_http_resp_t *resp, void *data) {
     if (resp->code < 0) {
         fprintf(stderr, "ERROR: %d(%s)", resp->code, uv_strerror(resp->code));

--- a/sample/common.c
+++ b/sample/common.c
@@ -18,13 +18,18 @@ limitations under the License.
 #include "common.h"
 
 void logger(int level, const char *file, unsigned int line, const char *msg) {
-    fprintf(stderr, "%s:%d %s\n", file, line, msg);
+
+    struct timespec spec;
+    clock_gettime(CLOCK_REALTIME, &spec);
+
+    fprintf(stderr, "[%9ld.%03ld] %s:%d %s\n", spec.tv_sec, spec.tv_nsec/1000000, file, line, msg);
 }
 
 void resp_cb(um_http_resp_t *resp, void *data) {
     if (resp->code < 0) {
         fprintf(stderr, "ERROR: %d(%s)", resp->code, uv_strerror(resp->code));
-        exit(-1);
+        //exit(-1);
+        return;
     }
     um_http_hdr *h;
     printf("Response (%d) >>>\nHeaders >>>\n", resp->code);
@@ -40,7 +45,7 @@ void body_cb(um_http_req_t *req, const char *body, ssize_t len) {
     }
     else if (len < 0) {
         fprintf(stderr, "error(%zd) %s", len, uv_strerror(len));
-        exit(-1);
+        //exit(-1);
     }
     else {
         printf("%*.*s", (int) len, (int) len, body);

--- a/sample/common.h
+++ b/sample/common.h
@@ -22,5 +22,5 @@ limitations under the License.
 
 void resp_cb(um_http_resp_t *resp, void *data);
 void body_cb(um_http_req_t *req, const char *body, ssize_t len);
-
+void logger(int level, const char *file, unsigned int line, const char *msg);
 #endif //UV_MBED_COMMON_H

--- a/sample/um-curl.c
+++ b/sample/um-curl.c
@@ -20,7 +20,7 @@ limitations under the License.
 #include "common.h"
 
 int main(int argc, char **argv) {
-    uv_mbed_set_debug(5, stdout);
+    uv_mbed_set_debug(5, logger);
     uv_loop_t *loop = uv_default_loop();
 
     um_http_t clt;

--- a/sample/um-curl.c
+++ b/sample/um-curl.c
@@ -17,21 +17,94 @@ limitations under the License.
 #include <uv_mbed/um_http.h>
 #include <string.h>
 #include <uv_mbed/uv_mbed.h>
+#include <getopt.h>
 #include "common.h"
 
-int main(int argc, char **argv) {
-    uv_mbed_set_debug(5, logger);
-    uv_loop_t *loop = uv_default_loop();
-
+struct app_ctx {
     um_http_t clt;
-    um_http_init(loop, &clt, "https://httpbin.org");
+    char *path;
+    int count;
+    int cycle;
+};
 
-    um_http_req_t *r = um_http_req(&clt, "POST", "/post", resp_cb, NULL);
+static void do_request(uv_timer_t *t) {
+    struct app_ctx *app = t->data;
+
+    um_http_req_t *r = um_http_req(&app->clt, "GET", app->path, resp_cb, NULL);
     r->resp.body_cb = body_cb;
 
-    const char *msg = "this is a test";
-    um_http_req_data(r, msg, strlen(msg), NULL);
+    if (app->count-- > 0) {
+        uv_timer_start(t, do_request, app->cycle * 1000, 0);
+    }
+}
 
+int main(int argc, char **argv) {
+    struct app_ctx app = {
+            .cycle = 10,
+    };
+
+    tls_context *tls = NULL;
+    char *CA = NULL;
+    char *cert = NULL;
+    char *key = NULL;
+
+    extern char *optarg;
+    extern int optind;
+    int c, err;
+    while((c = getopt(argc, argv, "C:c:k:r:t:d:")) != -1) {
+        switch (c) {
+            case 'C':
+                if (optarg) {
+                    CA = optarg;
+                }
+                break;
+            case 'c':
+                if (optarg) cert = optarg;
+                break;
+            case 'k':
+                if (optarg) key = optarg;
+                break;
+            case 'r':
+                if (optarg) app.count = atoi(optarg);
+                break;
+
+            case 't':
+                if (optarg) app.cycle = atoi(optarg);
+                break;
+            case 'd':
+                if (optarg) {
+                    int level = atoi(optarg);
+                    uv_mbed_set_debug(level, logger);
+                }
+                break;
+        }
+    }
+
+    char *url = argv[optind];
+    char *path = url;
+    for (int i = 0; i<3; i++) {
+        path = strchr(path + 1, '/');
+    }
+    app.path = path ? path : "/";
+
+    uv_loop_t *loop = uv_default_loop();
+    char *host_url = strndup(url, path - url);
+    um_http_init(loop, &app.clt, host_url);
+    um_http_idle_keepalive(&app.clt, -1);
+
+    if (CA || (cert && key)) {
+        tls = default_tls_context(CA, CA ? strlen(CA) + 1 : 0);
+
+        if (cert && key) {
+            tls->api->set_own_cert(tls->ctx, cert, strlen(cert), key, strlen(key));
+        }
+        um_http_set_ssl(&app.clt, tls);
+    }
+
+    uv_timer_t timer;
+    uv_timer_init(loop, &timer);
+    timer.data = &app;
+    uv_timer_start(&timer, do_request, 0, 0);
     uv_run(loop, UV_RUN_DEFAULT);
 }
 

--- a/src/engine_mbedtls.c
+++ b/src/engine_mbedtls.c
@@ -492,11 +492,10 @@ static void tls_debug_f(void *ctx, int level, const char *file, int line, const 
 
 static tls_handshake_state mbedtls_hs_state(void *engine) {
     struct mbedtls_engine *eng = (struct mbedtls_engine *) engine;
-    if (eng->ssl->state == MBEDTLS_SSL_HANDSHAKE_OVER) {
-        return TLS_HS_COMPLETE;
-    }
-    else {
-        return TLS_HS_CONTINUE;
+    switch (eng->ssl->state) {
+        case MBEDTLS_SSL_HANDSHAKE_OVER: return TLS_HS_COMPLETE;
+        case MBEDTLS_SSL_HELLO_REQUEST: return TLS_HS_BEFORE;
+        default: return TLS_HS_CONTINUE;
     }
 }
 

--- a/src/engine_openssl.c
+++ b/src/engine_openssl.c
@@ -433,11 +433,10 @@ static int tls_set_own_cert_p11(void *ctx, const char *cert_buf, size_t cert_len
 
 static tls_handshake_state tls_hs_state(void *engine) {
     struct openssl_engine *eng = (struct openssl_engine *) engine;
-    if (SSL_get_state(eng->ssl) == TLS_ST_OK) {
-        return TLS_HS_COMPLETE;
-    }
-    else {
-        return TLS_HS_CONTINUE;
+    switch (SSL_get_state(eng->ssl)) {
+        case TLS_ST_OK: return TLS_HS_COMPLETE;
+        case TLS_ST_BEFORE: return TLS_HS_BEFORE;
+        default: return TLS_HS_CONTINUE;
     }
 }
 


### PR DESCRIPTION
make sure tls_link.engine is reset before staring connection

fixes a problem when engine could get in bad state if connection was closed during handshake.