### PR TITLE
Refactor uv_mbed_t

### DIFF
--- a/include/uv_mbed/tcp_src.h
+++ b/include/uv_mbed/tcp_src.h
@@ -35,7 +35,7 @@ extern "C" {
 typedef struct tcp_src_s {
     UM_SRC_FIELDS
     uv_tcp_t conn;
-    int keepalive;
+    unsigned int keepalive;
     int nodelay:1;
 } tcp_src_t;
 
@@ -49,7 +49,7 @@ int tcp_src_init(uv_loop_t *l, tcp_src_t *tl);
 
 int tcp_src_nodelay(tcp_src_t *ts, int val);
 
-int tcp_src_keepalive(tcp_src_t *ts, int val);
+int tcp_src_keepalive(tcp_src_t *ts, int on, unsigned int val);
 
 #ifdef __cplusplus
 }

--- a/include/uv_mbed/tcp_src.h
+++ b/include/uv_mbed/tcp_src.h
@@ -35,6 +35,8 @@ extern "C" {
 typedef struct tcp_src_s {
     UM_SRC_FIELDS
     uv_tcp_t conn;
+    int keepalive;
+    int nodelay:1;
 } tcp_src_t;
 
 /**
@@ -44,6 +46,10 @@ typedef struct tcp_src_s {
  * @param tl the tcp_src link to initialize
  */
 int tcp_src_init(uv_loop_t *l, tcp_src_t *tl);
+
+int tcp_src_nodelay(tcp_src_t *ts, int val);
+
+int tcp_src_keepalive(tcp_src_t *ts, int val);
 
 #ifdef __cplusplus
 }

--- a/include/uv_mbed/uv_mbed.h
+++ b/include/uv_mbed/uv_mbed.h
@@ -19,8 +19,11 @@ limitations under the License.
 
 #include <uv.h>
 #include <stdbool.h>
+#include <uv_link_t.h>
 
+#include "tcp_src.h"
 #include "tls_engine.h"
+#include "tls_link.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,8 +44,6 @@ int uv_mbed_connect(uv_connect_t *req, uv_mbed_t *mbed, const char *host, int po
 
 int uv_mbed_connect_addr(uv_connect_t *req, uv_mbed_t *mbed, const struct addrinfo *addr, uv_connect_cb cb);
 
-int uv_mbed_set_blocking(uv_mbed_t *mbed, int blocking);
-
 int uv_mbed_read(uv_mbed_t *client, uv_alloc_cb, uv_read_cb);
 
 int uv_mbed_write(uv_write_t *req, uv_mbed_t *mbed, uv_buf_t *buf, uv_write_cb cb);
@@ -52,13 +53,17 @@ int uv_mbed_close(uv_mbed_t *session, uv_close_cb close_cb);
 int uv_mbed_free(uv_mbed_t *session);
 
 struct uv_mbed_s {
-    uv_stream_t _stream;
-    uv_tcp_t socket;
+    UV_LINK_FIELDS
+
+    tcp_src_t socket;
+    tls_link_t tls_link;
 
     tls_context *tls;
     tls_engine *tls_engine;
 
+    char *host;
     uv_connect_t *conn_req; //a place to stash a connection request
+    uv_close_cb close_cb;
 };
 
 size_t um_base64url_decode(const char *in, char **out, size_t *out_len);

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(sample sample.c)
+add_executable(sample sample.c common.c)
 
 target_link_libraries(sample PUBLIC uv_mbed)
 target_include_directories(sample PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/sample/sample.c
+++ b/sample/sample.c
@@ -17,6 +17,7 @@ limitations under the License.
 #include <uv.h>
 #include <stdlib.h>
 #include <uv_mbed/uv_mbed.h>
+#include "common.h"
 
 #define HOST "www.wttr.in"
 
@@ -42,7 +43,6 @@ void on_data(uv_stream_t *h, ssize_t nread, const uv_buf_t* buf) {
         fprintf(stderr, "read error %ld: %s\n", nread, uv_strerror((int) nread));
         uv_mbed_close((uv_mbed_t *) h, on_close);
     }
-
     free(buf->base);
 }
 
@@ -67,17 +67,18 @@ void on_connect(uv_connect_t *cr, int status) {
 
     uv_write_t *wr = malloc(sizeof(uv_write_t));
     char req[] = "GET / HTTP/1.1\r\n"
-                       "Accept: */*\r\n"
-                       "Connection: close\r\n"
+                 "Accept: */*\r\n"
+                 "Connection: close\r\n"
                  "Host: " HOST "\r\n"
                  "User-Agent: curl/0.5.0\r\n"
-                       "\r\n";
+                 "\r\n";
 
     uv_buf_t buf = uv_buf_init(req, sizeof(req));
     uv_mbed_write(wr, mbed, &buf, write_cb);
 }
 
 int main() {
+    uv_mbed_set_debug(5, logger);
 #if _WIN32
     //changes the output to UTF-8 so that the windows output looks correct and not all jumbly
     SetConsoleOutputCP(65001);

--- a/src/http.c
+++ b/src/http.c
@@ -328,7 +328,10 @@ static void process_requests(uv_async_t *ar) {
         if (c->connect_timeout > 0) {
             uv_timer_start(&c->conn_timer, src_connect_timeout, c->connect_timeout, 0);
         }
-        c->src->connect(c->src, c->host, c->port, src_connect_cb, c);
+        int rc = c->src->connect(c->src, c->host, c->port, src_connect_cb, c);
+        if (rc != 0) {
+            src_connect_cb(c->src, rc, c);
+        }
     }
     else if (c->connected == Connected) {
         UM_LOG(VERB, "client connected, processing request[%s] state[%d]", c->active->path, c->active->state);

--- a/src/tcp_src.c
+++ b/src/tcp_src.c
@@ -38,9 +38,9 @@ int tcp_src_nodelay(tcp_src_t *ts, int val) {
     return uv_tcp_nodelay(&ts->conn, val);
 }
 
-int tcp_src_keepalive(tcp_src_t *ts, int val) {
-    ts->keepalive = val;
-    return uv_tcp_keepalive(&ts->conn, val > 0, val);
+int tcp_src_keepalive(tcp_src_t *ts, int on, unsigned int val) {
+    ts->keepalive = on ? val : 0;
+    return uv_tcp_keepalive(&ts->conn, on, val);
 }
 
 static void tcp_connect_cb(uv_connect_t *req, int status) {

--- a/src/tcp_src.c
+++ b/src/tcp_src.c
@@ -69,10 +69,14 @@ static void resolve_cb(uv_getaddrinfo_t *req, int status, struct addrinfo *addr)
 
 static int tcp_src_connect(um_src_t *sl, const char* host, const char *service, um_src_connect_cb cb, void *ctx) {
     uv_getaddrinfo_t *resolv_req = malloc(sizeof(uv_getaddrinfo_t));
+    tcp_src_t *tcp = (tcp_src_t *) sl;
 
     sl->connect_cb = cb;
     sl->connect_ctx = ctx;
     resolv_req->data = sl;
+    if (uv_is_closing((const uv_handle_t *) &tcp->conn)) {
+        uv_tcp_init(sl->loop, &tcp->conn);
+    }
     int rc = uv_getaddrinfo(sl->loop, resolv_req, resolve_cb, host, service, NULL);
     if (rc != 0) {
         resolve_cb(resolv_req, rc, NULL);

--- a/src/tcp_src.c
+++ b/src/tcp_src.c
@@ -33,6 +33,16 @@ int tcp_src_init(uv_loop_t *l, tcp_src_t *tl) {
     return uv_tcp_init(l, &tl->conn);
 }
 
+int tcp_src_nodelay(tcp_src_t *ts, int val) {
+    ts->nodelay = val;
+    return uv_tcp_nodelay(&ts->conn, val);
+}
+
+int tcp_src_keepalive(tcp_src_t *ts, int val) {
+    ts->keepalive = val;
+    return uv_tcp_keepalive(&ts->conn, val > 0, val);
+}
+
 static void tcp_connect_cb(uv_connect_t *req, int status) {
     tcp_src_t *sl = req->data;
 
@@ -80,6 +90,8 @@ static int tcp_src_connect(um_src_t *sl, const char* host, const char *service, 
             cb(sl, rc, ctx);
             return rc;
         }
+        uv_tcp_nodelay(&tcp->conn, tcp->nodelay);
+        uv_tcp_keepalive(&tcp->conn, tcp->keepalive > 0, tcp->keepalive);
     }
 
     uv_getaddrinfo_t *resolv_req = malloc(sizeof(uv_getaddrinfo_t));

--- a/src/tcp_src.c
+++ b/src/tcp_src.c
@@ -30,8 +30,7 @@ int tcp_src_init(uv_loop_t *l, tcp_src_t *tl) {
     tl->connect_cb = NULL;
     tl->release = tcp_src_release;
     tl->cancel = tcp_src_cancel;
-
-    return 0;
+    return uv_tcp_init(l, &tl->conn);
 }
 
 static void tcp_connect_cb(uv_connect_t *req, int status) {
@@ -74,12 +73,7 @@ static int tcp_src_connect(um_src_t *sl, const char* host, const char *service, 
     sl->connect_cb = cb;
     sl->connect_ctx = ctx;
     resolv_req->data = sl;
-    int rc = uv_tcp_init(sl->loop, &((tcp_src_t *)sl)->conn);
-    if (rc != 0) {
-        cb(sl, rc, ctx);
-        return rc;
-    }
-    rc = uv_getaddrinfo(sl->loop, resolv_req, resolve_cb, host, service, NULL);
+    int rc = uv_getaddrinfo(sl->loop, resolv_req, resolve_cb, host, service, NULL);
     if (rc != 0) {
         resolve_cb(resolv_req, rc, NULL);
     }

--- a/src/tcp_src.c
+++ b/src/tcp_src.c
@@ -68,16 +68,24 @@ static void resolve_cb(uv_getaddrinfo_t *req, int status, struct addrinfo *addr)
 }
 
 static int tcp_src_connect(um_src_t *sl, const char* host, const char *service, um_src_connect_cb cb, void *ctx) {
-    uv_getaddrinfo_t *resolv_req = malloc(sizeof(uv_getaddrinfo_t));
     tcp_src_t *tcp = (tcp_src_t *) sl;
 
     sl->connect_cb = cb;
     sl->connect_ctx = ctx;
-    resolv_req->data = sl;
+    int rc;
     if (uv_is_closing((const uv_handle_t *) &tcp->conn)) {
-        uv_tcp_init(sl->loop, &tcp->conn);
+        rc = uv_tcp_init(sl->loop, &tcp->conn);
+        if (rc != 0) {
+            UM_LOG(ERR, "failed to reinit tcp_src: %d(%s)", rc, uv_strerror(rc));
+            cb(sl, rc, ctx);
+            return rc;
+        }
     }
-    int rc = uv_getaddrinfo(sl->loop, resolv_req, resolve_cb, host, service, NULL);
+
+    uv_getaddrinfo_t *resolv_req = malloc(sizeof(uv_getaddrinfo_t));
+    resolv_req->data = sl;
+
+    rc = uv_getaddrinfo(sl->loop, resolv_req, resolve_cb, host, service, NULL);
     if (rc != 0) {
         resolve_cb(resolv_req, rc, NULL);
     }

--- a/src/tcp_src.c
+++ b/src/tcp_src.c
@@ -87,22 +87,16 @@ static int tcp_src_connect(um_src_t *sl, const char* host, const char *service, 
         rc = uv_tcp_init(sl->loop, &tcp->conn);
         if (rc != 0) {
             UM_LOG(ERR, "failed to reinit tcp_src: %d(%s)", rc, uv_strerror(rc));
-            cb(sl, rc, ctx);
             return rc;
         }
         uv_tcp_nodelay(&tcp->conn, tcp->nodelay);
         uv_tcp_keepalive(&tcp->conn, tcp->keepalive > 0, tcp->keepalive);
     }
 
-    uv_getaddrinfo_t *resolv_req = malloc(sizeof(uv_getaddrinfo_t));
+    uv_getaddrinfo_t *resolv_req = calloc(1, sizeof(uv_getaddrinfo_t));
     resolv_req->data = sl;
 
-    rc = uv_getaddrinfo(sl->loop, resolv_req, resolve_cb, host, service, NULL);
-    if (rc != 0) {
-        resolve_cb(resolv_req, rc, NULL);
-    }
-
-    return rc;
+    return uv_getaddrinfo(sl->loop, resolv_req, resolve_cb, host, service, NULL);
 }
 
 static void tcp_src_cancel(um_src_t *sl) {

--- a/src/tls_link.c
+++ b/src/tls_link.c
@@ -88,9 +88,9 @@ static int tls_read_start(uv_link_t *l) {
     tls_link_t *tls = (tls_link_t *) l;
 
     tls_handshake_state st = tls->engine->api->handshake_state(tls->engine->engine);
-    UM_LOG(VERB, "starting TLS handshake(st = %d)", st);
+    UM_LOG(VERB, "TLS(%p) starting handshake(st = %d)", tls, st);
     if (st == TLS_HS_CONTINUE) {
-        UM_LOG(DEBG, "tls_link is in the middle of handshake, resetting");
+        UM_LOG(DEBG, "TLS(%p) is in the middle of handshake, resetting", tls);
         if (tls->engine->api->reset) {
             tls->engine->api->reset(tls->engine->engine);
         }
@@ -102,7 +102,7 @@ static int tls_read_start(uv_link_t *l) {
     buf.base = malloc(32 * 1024);
     st = tls->engine->api->handshake(tls->engine->engine, NULL, 0, buf.base, &buf.len,
                                                          32 * 1024);
-    UM_LOG(VERB, "starting TLS handshake(sending %zd bytes, st = %d)", buf.len, st);
+    UM_LOG(VERB, "TLS(%p) starting handshake(sending %zd bytes, st = %d)", tls, buf.len, st);
 
     tls_link_write_t *wr = calloc(1, sizeof(tls_link_write_t));
     wr->tls_buf = buf.base;
@@ -163,7 +163,7 @@ static void tls_read_cb(uv_link_t *l, ssize_t nread, const uv_buf_t *b) {
         }
         if (b->base) free(b->base);
     } else if (hs_state == TLS_HS_COMPLETE) {
-        UM_LOG(VERB, "TLS(%p) processing %zd bytes", nread);
+        UM_LOG(VERB, "TLS(%p) processing %zd bytes", tls, nread);
 
         size_t read = 0;
         size_t buf_size = b->len;

--- a/src/uv_mbed.c
+++ b/src/uv_mbed.c
@@ -30,17 +30,15 @@ limitations under the License.
 #endif
 
 static void tls_debug_f(void *ctx, int level, const char *file, int line, const char *str);
-static void dns_resolve_cb(uv_getaddrinfo_t* req, int status, struct addrinfo* res);
-
 static void tcp_connect_cb(uv_connect_t* req, int status);
-static void tcp_shutdown_cb(uv_shutdown_t* req, int status) ;
 static int mbed_ssl_send(void* ctx, const uint8_t *buf, size_t len);
 
-static int mbed_tcp_write(uv_mbed_t *mbed, char *buf, size_t len, uv_write_t *wr);
-
-struct tcp_write_ctx {
-    uint8_t *buf;
-    uv_write_t *req;
+static const uv_link_methods_t mbed_methods = {
+        .close = uv_link_default_close,
+        .read_start = uv_link_default_read_start,
+        .write = uv_link_default_write,
+        .alloc_cb_override = uv_link_default_alloc_cb_override,
+        .read_cb_override = uv_link_default_read_cb_override,
 };
 
 static tls_context *DEFAULT_TLS = NULL;
@@ -57,295 +55,97 @@ const char* uv_mbed_version() {
 }
 
 int uv_mbed_init(uv_loop_t *l, uv_mbed_t *mbed, tls_context *tls) {
-    memset(&mbed->_stream, 0, sizeof(uv_stream_t));
-    mbed->_stream.loop = l;
-    mbed->_stream.type = UV_STREAM;
-
-    uv_tcp_init(l, &mbed->socket);
-
+    tcp_src_init(l, &mbed->socket);
     mbed->tls = tls != NULL ? tls : get_default_tls();
     mbed->tls_engine = NULL;
 
     return 0;
 }
 
-int uv_mbed_connect_addr(uv_connect_t *req, uv_mbed_t* mbed, const struct addrinfo *addr, uv_connect_cb cb) {
-
-    if (mbed->conn_req != NULL && mbed->conn_req != req) {
-        return UV_EALREADY;
-    }
-
-    req->handle = (uv_stream_t *) mbed;
-    req->cb = cb;
-    mbed->conn_req = req;
-
-    uv_connect_t *tcp_cr = calloc(1, sizeof(uv_connect_t));
-    tcp_cr->data = mbed;
-    return uv_tcp_connect(tcp_cr, &mbed->socket, addr->ai_addr, tcp_connect_cb);
-}
-
-static void on_close_write(uv_write_t *req, int status) {
-    struct uv_mbed_s *mbed = (struct uv_mbed_s *) req->handle;
-
-    uv_shutdown_t *sr = malloc(sizeof(uv_shutdown_t));
-    sr->data = mbed;
-    uv_shutdown(sr, (uv_stream_t *) &mbed->socket, tcp_shutdown_cb);
-    free(req);
+static void on_mbed_close(uv_link_t *l) {
+    uv_mbed_t *mbed = (uv_mbed_t *) l;
+    mbed->tls->api->free_engine(mbed->tls_engine);
+    mbed->tls_engine = NULL;
+    if(mbed->close_cb) mbed->close_cb((uv_handle_t *) mbed);
 }
 
 int uv_mbed_close(uv_mbed_t *mbed, uv_close_cb close_cb) {
-
-    mbed->_stream.close_cb = close_cb;
-    size_t out_size = 32 * 1024;
-    char *buf = malloc(out_size);
-    size_t out_len;
-    mbed->tls_engine->api->close(mbed->tls_engine->engine, buf, &out_len, out_size);
-    uv_write_t *wr = calloc(1, sizeof(uv_write_t));
-    wr->handle = mbed;
-    wr->cb = on_close_write;
-    mbed_tcp_write(mbed, buf, out_len, wr);
+    mbed->close_cb = close_cb;
+    uv_link_close((uv_link_t *) mbed, on_mbed_close);
     return 0;
 }
 
 int uv_mbed_keepalive(uv_mbed_t *mbed, int keepalive, unsigned int delay) {
-    return uv_tcp_keepalive(&mbed->socket, keepalive, delay);
+    return uv_tcp_keepalive(&mbed->socket.conn, keepalive, delay);
 }
 
 int uv_mbed_nodelay(uv_mbed_t *mbed, int nodelay) {
-    return uv_tcp_nodelay(&mbed->socket, nodelay);
+    return uv_tcp_nodelay(&mbed->socket.conn, nodelay);
 }
 
+static void on_tls_hs(tls_link_t *tls_link, int status) {
+    uv_mbed_t *mbed = tls_link->data;
+    mbed->conn_req->cb(mbed->conn_req, status);
+}
+static void on_src_connect(um_src_t *src, int status, void *ctx) {
+    uv_mbed_t *mbed = ctx;
+
+    if (status == 0) {
+        if (mbed->tls_engine == NULL) {
+            mbed->tls_engine = mbed->tls->api->new_engine(mbed->tls->ctx, mbed->conn_req->data);
+        }
+        um_tls_init(&mbed->tls_link, mbed->tls_engine, on_tls_hs);
+        uv_link_init((uv_link_t *) mbed, &mbed_methods);
+
+        mbed->tls_link.data = mbed;
+        uv_link_chain(src->link, (uv_link_t *)&mbed->tls_link);
+        uv_link_chain((uv_link_t *) &mbed->tls_link, (uv_link_t *) mbed);
+        uv_link_read_start((uv_link_t *) mbed);
+    } else {
+        UM_LOG(WARN, "failed to connect");
+    }
+}
 int uv_mbed_connect(uv_connect_t *req, uv_mbed_t *mbed, const char *host, int port, uv_connect_cb cb) {
-    uv_loop_t *loop = mbed->_stream.loop;
-    uv_getaddrinfo_t *resolve_req = calloc(1, sizeof(uv_getaddrinfo_t));
-    req->handle = (uv_stream_t *) mbed;
-    req->cb = cb;
-    mbed->conn_req = req;
-    
-    resolve_req->data = mbed;
+
     char portstr[6];
     sprintf(portstr, "%d", port);
 
-    mbed->tls_engine = mbed->tls->api->new_engine(mbed->tls->ctx, host);
+    req->handle = (uv_stream_t *) mbed;
+    req->cb = cb;
+    mbed->host = strdup(host);
+    mbed->conn_req = req;
 
-    UM_LOG(VERB, "resolving host = %s:%s", host, portstr);
-    int resolve_rc =  uv_getaddrinfo(loop, resolve_req, NULL, host, portstr, NULL);
-    if (resolve_rc != 0) {
-        UM_LOG(ERR, "failed to resolve host[%s]: %s", host, uv_strerror(resolve_rc));
-        return resolve_rc;
-    }
-
-    dns_resolve_cb(resolve_req, 0, resolve_req->addrinfo);
-    return 0;
-}
-
-int uv_mbed_set_blocking(uv_mbed_t *um, int blocking) {
-    return uv_stream_set_blocking((uv_stream_t *) &um->socket, blocking);
+    return mbed->socket.connect((um_src_t *) &mbed->socket, host, portstr, on_src_connect, mbed);
 }
 
 int uv_mbed_read(uv_mbed_t *mbed, uv_alloc_cb alloc_cb, uv_read_cb read_cb) {
-    mbed->_stream.alloc_cb = alloc_cb;
-    mbed->_stream.read_cb = read_cb;
+    mbed->alloc_cb = (uv_link_alloc_cb) alloc_cb;
+    mbed->read_cb = (uv_link_read_cb) read_cb;
+    uv_link_read_start((uv_link_t *) mbed);
     return 0;
+}
+
+static void on_mbed_link_write(uv_link_t* l, int status, void *ctx) {
+    uv_write_t *wr = ctx;
+    wr->cb(wr, status);
 }
 
 int uv_mbed_write(uv_write_t *req, uv_mbed_t *mbed, uv_buf_t *buf, uv_write_cb cb) {
     req->handle = (uv_stream_t *) mbed;
-
-    size_t out_size = 32 * 1024;
-    char *out = malloc(out_size);
-    size_t out_len;
-    int rc = mbed->tls_engine->api->write(mbed->tls_engine->engine, buf->base, buf->len, out, &out_len, out_size);
-    if (rc < 0) {
-        free(out);
-        return rc;
-    }
-
-    if (rc > 0) {
-        if (out_len + rc > out_size) {
-            out = realloc(out, out_len + rc);
-        }
-        size_t addt_bytes = 0;
-        rc = mbed->tls_engine->api->write(mbed->tls_engine->engine, NULL, 0, out + out_len, &addt_bytes, rc);
-        if (rc < 0) {
-            UM_LOG(ERR, "TLS write error: %s", mbed->tls_engine->api->strerror(mbed->tls_engine));
-            free(out);
-            return rc;
-        } else {
-            out_len += addt_bytes;
-        }
-    }
-
-
     req->cb = cb;
-    return mbed_tcp_write(mbed, out, out_len, req);
+    return uv_link_write((uv_link_t *) mbed, buf, 1, NULL, on_mbed_link_write, req);
 }
 
 int uv_mbed_free(uv_mbed_t *mbed) {
-    mbed->tls->api->free_engine(mbed->tls_engine);
-    return 0;
-}
-
-static void tls_debug_f(void *ctx, int level, const char *file, int line, const char *str)
-{
-    printf("%s:%04d: %s", file, line, str );
-    fflush(  stdout );
-}
-
-static void um_alloc_cb(uv_handle_t *h, size_t suggested_size, uv_buf_t *buf) {
-    uv_mbed_t *mbed = h->data;
-
-    // still in handshake, allocate memory internally
-    if (mbed->tls_engine->api->handshake_state(mbed->tls_engine->engine) == TLS_HS_CONTINUE) {
-        buf->base = (char*) malloc(suggested_size);
-        buf->len = buf->base != NULL ? suggested_size : 0;
-    } else {
-        // call client alloc to allow client signal backpressure via ENOBUFS
-        mbed->_stream.alloc_cb((uv_handle_t *) mbed, suggested_size, buf);
+    if (mbed->host) {
+        free(mbed->host);
+        mbed->host = NULL;
     }
-}
-
-static void dns_resolve_cb(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
-    uv_mbed_t *mbed = req->data;
-
-    uv_connect_t *cr = mbed->conn_req;
-    UM_LOG(VERB, "resolved status = %d", status);
-    if (status < 0) {
-        UM_LOG(ERR, "failed to resolve host: %s", uv_strerror(status));
-        cr->cb(cr, status);
-    } else {
-        int rc = uv_mbed_connect_addr(cr, mbed, res, cr->cb);
-        if (rc != 0) {
-            char *ip = inet_ntoa(((struct sockaddr_in *)res->ai_addr)->sin_addr);
-            UM_LOG(ERR, "failed to connect to [%s]: %s", ip, uv_strerror(rc));
-            cr->cb(cr, rc);
-        }
+    if (mbed->tls_engine) {
+        mbed->tls->api->free_engine(mbed->tls_engine);
+        mbed->tls_engine = NULL;
     }
-    uv_freeaddrinfo(res);
-    free(req);
-}
-
-static void tcp_read_cb (uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
-    uv_mbed_t *mbed = stream->data;
-    if (nread > 0) {
-        if (mbed->tls_engine->api->handshake_state(mbed->tls_engine->engine) == TLS_HS_CONTINUE) {
-            size_t out_size = 32 * 1024;
-            char *out = malloc(out_size);
-            size_t out_len;
-            tls_handshake_state st = mbed->tls_engine->api->handshake(mbed->tls_engine->engine, buf->base, nread, out,
-                                                                      &out_len, out_size);
-            if (out_len > 0) {
-                mbed_tcp_write(mbed, out, out_len, NULL);
-            }
-            else {
-                free(out);
-            }
-            if (st == TLS_HS_COMPLETE && mbed->conn_req) {
-                mbed->conn_req->cb(mbed->conn_req, 0);
-                mbed->conn_req = NULL;
-            }
-
-            if (buf->base != NULL) {
-                free(buf->base);
-            }
-        }
-        else {
-            int rc = TLS_MORE_AVAILABLE;
-            ssize_t recv = 0;
-            uv_buf_t local_buf;
-            while (rc == TLS_MORE_AVAILABLE) {
-                // NB: we use client allocated memory in buf for input and output
-                rc = mbed->tls_engine->api->read(mbed->tls_engine->engine, buf->base, nread, buf->base, (size_t *) &recv,
-                                                     buf->len);
-                mbed->_stream.read_cb((uv_stream_t *) mbed, recv, buf);
-
-                if (rc == TLS_MORE_AVAILABLE) {
-                    // more data in TSL engine, use local buf
-                    mbed->_stream.alloc_cb((uv_handle_t *) mbed, 64 * 1024, &local_buf);
-                    if (local_buf.base == 0 || local_buf.len == 0) { // client can't take any more
-                        mbed->_stream.read_cb((uv_stream_t*)mbed, ENOBUFS, &local_buf);
-                        break;
-                    } else {
-                        nread = 0;
-                        buf = &local_buf;
-                    }
-                }
-            }
-        }
-    }
-
-    if (nread < 0) {
-        // still connecting
-       if (mbed->conn_req != NULL) {
-            mbed->conn_req->cb(mbed->conn_req, nread);
-            mbed->conn_req = NULL;
-            free(buf->base);
-       }
-       else {
-            mbed->_stream.read_cb((uv_stream_t *) mbed, nread, buf);
-        }
-    }
-}
-
-static void tcp_connect_cb(uv_connect_t *req, int status) {
-    uv_mbed_t *mbed = req->data;
-    if (status < 0) {
-        mbed->conn_req->cb(mbed->conn_req, status);
-    }
-    else {
-        req->handle->data = mbed;
-        uv_read_start(req->handle, um_alloc_cb, tcp_read_cb);
-        // start handshake
-        size_t out_size = 32 * 1024;
-        char *out = malloc(out_size);
-        size_t out_len;
-        UM_LOG(VERB, "starting handshake");
-        mbed->tls_engine->api->handshake(mbed->tls_engine->engine, NULL, 0, out, &out_len, out_size);
-        mbed_tcp_write(mbed, out, out_len, NULL);
-    }
-    free(req);
-}
-
-static void on_mbed_close(uv_handle_t *h) {
-    uv_mbed_t *mbed = h->data;
-    mbed->_stream.close_cb((uv_handle_t *) mbed);
-}
-
-static void tcp_shutdown_cb(uv_shutdown_t* req, int status) {
-    uv_mbed_t *mbed = req->data;
-
-    uv_close((uv_handle_t *) &mbed->socket, on_mbed_close);
-    free(req);
-}
-
-static void mbed_tcp_write_cb(uv_write_t *tcp_wr, int status) {
-    struct tcp_write_ctx *ctx = tcp_wr->data;
-    uv_write_t *ssl_wr = ctx->req;
-
-    if (ssl_wr != NULL) {
-        ssl_wr->cb(ssl_wr, status);
-    }
-    else if (tcp_wr->cb) {
-       // tcp_wr->cb(tcp_wr, status);
-    }
-    free(ctx->buf);
-    free(ctx);
-    free(tcp_wr);
-}
-
-static int mbed_tcp_write(uv_mbed_t *mbed, char *buf, size_t len, uv_write_t *wr) {
-    if (len > 0) {
-        struct tcp_write_ctx *ctx = malloc(sizeof(struct tcp_write_ctx));
-        ctx->buf = buf;
-        memcpy(ctx->buf, buf, len);
-
-        ctx->req = wr;
-
-        uv_write_t *tcp_wr = calloc(1, sizeof(uv_write_t));
-        tcp_wr->data = ctx;
-        uv_buf_t wb = uv_buf_init((char *) ctx->buf, (unsigned int) len);
-        return uv_write(tcp_wr, (uv_stream_t *) &mbed->socket, &wb, 1, mbed_tcp_write_cb);
-    }
+    mbed->socket.release((um_src_t *) &mbed->socket);
     return 0;
 }
 

--- a/src/uv_mbed.c
+++ b/src/uv_mbed.c
@@ -109,6 +109,7 @@ static void on_src_connect(um_src_t *src, int status, void *ctx) {
     } else {
         UM_LOG(WARN, "failed to connect");
         mbed->conn_req->cb(mbed->conn_req, status);
+        mbed->conn_req = NULL;
     }
 }
 int uv_mbed_connect(uv_connect_t *req, uv_mbed_t *mbed, const char *host, int port, uv_connect_cb cb) {

--- a/src/uv_mbed.c
+++ b/src/uv_mbed.c
@@ -108,6 +108,7 @@ static void on_src_connect(um_src_t *src, int status, void *ctx) {
         uv_link_read_start((uv_link_t *) mbed);
     } else {
         UM_LOG(WARN, "failed to connect");
+        mbed->conn_req->cb(mbed->conn_req, status);
     }
 }
 int uv_mbed_connect(uv_connect_t *req, uv_mbed_t *mbed, const char *host, int port, uv_connect_cb cb) {
@@ -126,7 +127,7 @@ int uv_mbed_connect(uv_connect_t *req, uv_mbed_t *mbed, const char *host, int po
 int uv_mbed_read(uv_mbed_t *mbed, uv_alloc_cb alloc_cb, uv_read_cb read_cb) {
     mbed->alloc_cb = (uv_link_alloc_cb) alloc_cb;
     mbed->read_cb = (uv_link_read_cb) read_cb;
-    uv_link_read_start((uv_link_t *) mbed);
+    // uv_link_read_start((uv_link_t *) mbed);
     return 0;
 }
 

--- a/src/uv_mbed.c
+++ b/src/uv_mbed.c
@@ -65,8 +65,6 @@ int uv_mbed_init(uv_loop_t *l, uv_mbed_t *mbed, tls_context *tls) {
 
 static void on_mbed_close(uv_link_t *l) {
     uv_mbed_t *mbed = (uv_mbed_t *) l;
-    mbed->tls->api->free_engine(mbed->tls_engine);
-    mbed->tls_engine = NULL;
     if(mbed->close_cb) mbed->close_cb((uv_handle_t *) mbed);
 }
 

--- a/src/uv_mbed.c
+++ b/src/uv_mbed.c
@@ -77,11 +77,11 @@ int uv_mbed_close(uv_mbed_t *mbed, uv_close_cb close_cb) {
 }
 
 int uv_mbed_keepalive(uv_mbed_t *mbed, int keepalive, unsigned int delay) {
-    return uv_tcp_keepalive(&mbed->socket.conn, keepalive, delay);
+    return tcp_src_keepalive(&mbed->socket, keepalive, delay);
 }
 
 int uv_mbed_nodelay(uv_mbed_t *mbed, int nodelay) {
-    return uv_tcp_nodelay(&mbed->socket.conn, nodelay);
+    return tcp_src_nodelay(&mbed->socket, nodelay);
 }
 
 static void on_tls_hs(tls_link_t *tls_link, int status) {

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -236,9 +236,7 @@ int um_websocket_write(uv_write_t *req, um_websocket_t *ws, uv_buf_t *buf, uv_wr
     ws_wreq->nbufs = 1;
     ws_wreq->cb = cb;
 
-    uv_link_write(&ws->ws_link, &bufs, 1, NULL, ws_write_cb, ws_wreq);
-
-    return 0;
+    return uv_link_write(&ws->ws_link, &bufs, 1, NULL, ws_write_cb, ws_wreq);
 }
 
 

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -113,7 +113,8 @@ int um_websocket_connect(uv_connect_t *req, um_websocket_t *ws, const char *url,
 
     struct http_parser_url _url;
     if (http_parser_parse_url(url, strlen(url), false, &_url) !=0) {
-        return UV_EADDRNOTAVAIL;
+        UM_LOG(ERR, "invalid websocket URL: %s", url);
+        return UV_EINVAL;
     }
 
     bool ssl = false;
@@ -182,9 +183,7 @@ int um_websocket_connect(uv_connect_t *req, um_websocket_t *ws, const char *url,
 
     ws->host = host;
     ws->read_cb = read_cb;
-    ws->src->connect(ws->src, host, portstr, src_connect_cb, req);
-
-    return 0;
+    return ws->src->connect(ws->src, host, portstr, src_connect_cb, req);
 }
 
 int um_websocket_write(uv_write_t *req, um_websocket_t *ws, uv_buf_t *buf, uv_write_cb cb) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_srcs
         http_tests.cpp
         ws_tests.cpp
         engine_tests.cpp
-        )
+        uv_mbed_tests.cpp)
 
 
 add_executable(all_tests

--- a/tests/uv_mbed_tests.cpp
+++ b/tests/uv_mbed_tests.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright 2019-2021 NetFoundry, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <uv.h>
+#include <uv_mbed/uv_mbed.h>
+#include <cstring>
+#include "catch.hpp"
+
+TEST_CASE("uv-mbed connect fail", "[uv-mbed]") {
+    uv_loop_t *l = uv_loop_new();
+    uv_mbed_t mbed;
+    tls_context *tls = default_tls_context(nullptr, 0);
+    uv_mbed_init(l, &mbed, tls);
+
+    uv_connect_t cr;
+    int conn_cb_called = 0;
+    cr.data = &conn_cb_called;
+
+    uv_connect_cb cb = [](uv_connect_t *r, int status) -> void {
+        int *countp = (int*)r->data;
+        *countp = *countp + 1;
+        printf("conn cb called status = %d(%s)\n", status, status != 0 ? uv_strerror(status) : "");
+    };
+    int rc = 0;
+    WHEN("connect fail") {
+        rc = uv_mbed_connect(&cr, &mbed, "127.0.0.1", 62443, cb);
+    }
+    WHEN("resolve fail") {
+        rc = uv_mbed_connect(&cr, &mbed, "foo.bar.baz", 443, cb);
+    }
+
+    printf ("conn rc = %d(%s)\n", rc, rc ? uv_strerror(rc) : "");
+    uv_run(l, UV_RUN_DEFAULT);
+
+    CHECK( ((rc == 0 && conn_cb_called == 1) || (rc != 0 && conn_cb_called == 0)) );
+    uv_mbed_free(&mbed);
+    uv_loop_close(l);
+    uv_run(l, UV_RUN_DEFAULT);
+
+    free(l);
+
+    tls->api->free_ctx(tls);
+}

--- a/tests/ws_tests.cpp
+++ b/tests/ws_tests.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <uv_mbed/um_http.h>
 #include <uv_mbed/um_websocket.h>
 #include <cstring>
+#include <uv_mbed/uv_mbed.h>
 #include "catch.hpp"
 
 static void test_timeout(uv_timer_t *t) {


### PR DESCRIPTION
Re-implements `uv_mbed_t` by re-using `tcp_src_t` and `tls_link_t`
