### PR TITLE
Update mbedtls dependency

### DIFF
--- a/deps/mbedtls.cmake
+++ b/deps/mbedtls.cmake
@@ -1,7 +1,7 @@
 include(FetchContent)
 FetchContent_Declare(mbedtls
         GIT_REPOSITORY https://github.com/netfoundry/mbedtls.git
-        GIT_TAG verify-ip-sans+gcc11+mingw-stdio_2.x
+        GIT_TAG verify-ip-sans-properly-20210505
         GIT_SHALLOW 1
 )
 

--- a/deps/mbedtls.cmake
+++ b/deps/mbedtls.cmake
@@ -1,7 +1,7 @@
 include(FetchContent)
 FetchContent_Declare(mbedtls
         GIT_REPOSITORY https://github.com/netfoundry/mbedtls.git
-        GIT_TAG verify-ip-sans-v2.23.0
+        GIT_TAG verify-ip-sans-properly-20210505
         GIT_SHALLOW 1
 )
 

--- a/deps/mbedtls.cmake
+++ b/deps/mbedtls.cmake
@@ -1,7 +1,7 @@
 include(FetchContent)
 FetchContent_Declare(mbedtls
         GIT_REPOSITORY https://github.com/netfoundry/mbedtls.git
-        GIT_TAG verify-ip-sans-properly-20210505
+        GIT_TAG verify-ip-sans+gcc11+mingw-stdio_development
         GIT_SHALLOW 1
 )
 

--- a/deps/mbedtls.cmake
+++ b/deps/mbedtls.cmake
@@ -1,7 +1,7 @@
 include(FetchContent)
 FetchContent_Declare(mbedtls
         GIT_REPOSITORY https://github.com/netfoundry/mbedtls.git
-        GIT_TAG verify-ip-sans-properly-20210505
+        GIT_TAG verify-ip-sans+gcc11+mingw-stdio_2.x
         GIT_SHALLOW 1
 )
 

--- a/deps/mbedtls.cmake
+++ b/deps/mbedtls.cmake
@@ -1,7 +1,7 @@
 include(FetchContent)
 FetchContent_Declare(mbedtls
         GIT_REPOSITORY https://github.com/netfoundry/mbedtls.git
-        GIT_TAG verify-ip-sans+gcc11+mingw-stdio_2.x
+        GIT_TAG verify-ip-sans-properly_2.x
         GIT_SHALLOW 1
 )
 

--- a/deps/mbedtls.cmake
+++ b/deps/mbedtls.cmake
@@ -1,7 +1,7 @@
 include(FetchContent)
 FetchContent_Declare(mbedtls
         GIT_REPOSITORY https://github.com/netfoundry/mbedtls.git
-        GIT_TAG verify-ip-sans+gcc11+mingw-stdio_development
+        GIT_TAG verify-ip-sans+gcc11+mingw-stdio_2.x
         GIT_SHALLOW 1
 )
 

--- a/src/engine_mbedtls.c
+++ b/src/engine_mbedtls.c
@@ -382,7 +382,10 @@ static void mbedtls_free(tls_engine *engine) {
     um_BIO_free(e->out);
 
     mbedtls_ssl_free(e->ssl);
-    free(e->ssl);
+    if (e->ssl) {
+        free(e->ssl);
+        e->ssl = NULL;
+    }
     if (e->session) {
         mbedtls_ssl_session_free(e->session);
         free(e->session);

--- a/src/p11/p11_mbedtls/p11_ecdsa.c
+++ b/src/p11/p11_mbedtls/p11_ecdsa.c
@@ -136,11 +136,11 @@ static int p11_ecdsa_sign(void *ctx, mbedtls_md_type_t md_alg,
 
     rc = p11->funcs->C_SignInit(p11->session, &mech, p11key->priv_handle);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
     }
     rc = p11->funcs->C_Sign(p11->session, hash, hash_len, rawsig, &rawsig_len);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
     }
 
     mbedtls_mpi r, s;

--- a/src/p11/p11_mbedtls/p11_ecdsa.c
+++ b/src/p11/p11_mbedtls/p11_ecdsa.c
@@ -40,33 +40,8 @@ static void p11_ecdsa_free(void *ctx);
 static int ecdsa_signature_to_asn1(const mbedtls_mpi *r, const mbedtls_mpi *s,
                                    unsigned char *sig, size_t *slen);
 
-#if 0
-const mbedtls_pk_info_t p11_ecdsa_info = {
-        MBEDTLS_PK_ECDSA,
-        "ECDSA",
-        p11_ecdsa_bitlen,
-        p11_ecdsa_can_do,
-        p11_ecdsa_verify,
-        p11_ecdsa_sign,
-#if defined(MBEDTLS_ECP_RESTARTABLE)
-ecdsa_verify_rs_wrap,
-ecdsa_sign_rs_wrap,
-#endif
-        NULL,
-        NULL,
-        NULL, //eckey_check_pair,   /* Compatible key structures */
-        NULL, //ecdsa_alloc_wrap,
-        p11_ecdsa_free,
-#if defined(MBEDTLS_ECP_RESTARTABLE)
-ecdsa_rs_alloc,
-ecdsa_rs_free,
-#endif
-        NULL, //eckey_debug,        /* Compatible key structures */
-};
-#endif
-
 int p11_load_ecdsa(mbedtls_pk_context *pk, struct mp11_key_ctx_s *p11key, mp11_context *p11) {
-    pk->pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_ECDSA);
+    pk->pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_ECDSA);
     pk->pk_ctx = p11key;
     p11key->ctx = p11;
 

--- a/src/p11/p11_mbedtls/p11_ecdsa.c
+++ b/src/p11/p11_mbedtls/p11_ecdsa.c
@@ -17,7 +17,7 @@ limitations under the License.
 #include <stdlib.h>
 #include <string.h>
 #include <mbedtls/pk.h>
-#include <mbedtls/pk_internal.h>
+#include <mbedtls/error.h>
 #include "mbed_p11.h"
 #include <mbedtls/asn1write.h>
 #include <mbedtls/oid.h>
@@ -40,6 +40,7 @@ static void p11_ecdsa_free(void *ctx);
 static int ecdsa_signature_to_asn1(const mbedtls_mpi *r, const mbedtls_mpi *s,
                                    unsigned char *sig, size_t *slen);
 
+#if 0
 const mbedtls_pk_info_t p11_ecdsa_info = {
         MBEDTLS_PK_ECDSA,
         "ECDSA",
@@ -62,9 +63,10 @@ ecdsa_rs_free,
 #endif
         NULL, //eckey_debug,        /* Compatible key structures */
 };
+#endif
 
 int p11_load_ecdsa(mbedtls_pk_context *pk, struct mp11_key_ctx_s *p11key, mp11_context *p11) {
-    pk->pk_info = &p11_ecdsa_info;
+    pk->pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_ECDSA);
     pk->pk_ctx = p11key;
     p11key->ctx = p11;
 
@@ -159,11 +161,11 @@ static int p11_ecdsa_sign(void *ctx, mbedtls_md_type_t md_alg,
 
     rc = p11->funcs->C_SignInit(p11->session, &mech, p11key->priv_handle);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
     }
     rc = p11->funcs->C_Sign(p11->session, hash, hash_len, rawsig, &rawsig_len);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
     }
 
     mbedtls_mpi r, s;

--- a/src/p11/p11_mbedtls/p11_ecdsa.c
+++ b/src/p11/p11_mbedtls/p11_ecdsa.c
@@ -136,11 +136,11 @@ static int p11_ecdsa_sign(void *ctx, mbedtls_md_type_t md_alg,
 
     rc = p11->funcs->C_SignInit(p11->session, &mech, p11key->priv_handle);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
     }
     rc = p11->funcs->C_Sign(p11->session, hash, hash_len, rawsig, &rawsig_len);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
     }
 
     mbedtls_mpi r, s;

--- a/src/p11/p11_mbedtls/p11_rsa.c
+++ b/src/p11/p11_mbedtls/p11_rsa.c
@@ -125,7 +125,7 @@ static int p11_rsa_sign(void *ctx, mbedtls_md_type_t md_alg,
     size_t oid_len = 0;
     rc = get_md_prefix(md_alg, &oid, &oid_len);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
     }
 
     CK_BYTE *msg = malloc(hash_len + oid_len);
@@ -134,12 +134,12 @@ static int p11_rsa_sign(void *ctx, mbedtls_md_type_t md_alg,
 
     rc = p11->funcs->C_SignInit(p11->session, &mech, p11key->priv_handle);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
     }
 
     rc = p11->funcs->C_Sign(p11->session, msg, hash_len + oid_len, rawsig, &rawsig_len);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
     }
 
     memcpy(sig, rawsig, rawsig_len);

--- a/src/p11/p11_mbedtls/p11_rsa.c
+++ b/src/p11/p11_mbedtls/p11_rsa.c
@@ -41,31 +41,6 @@ static void p11_rsa_free(void *ctx);
 
 static int get_md_prefix(mbedtls_md_type_t md, const char **prefix, size_t *len);
 
-#if 0
-const mbedtls_pk_info_t p11_rsa_info = {
-        MBEDTLS_PK_RSA,
-        "RSA",
-        p11_rsa_bitlen,
-        p11_rsa_can_do,
-        p11_rsa_verify,
-        p11_rsa_sign,
-#if defined(MBEDTLS_ECP_RESTARTABLE)
-rsa_verify_rs_wrap,
-rsa_sign_rs_wrap,
-#endif
-        NULL,
-        NULL,
-        NULL, //eckey_check_pair,   /* Compatible key structures */
-        NULL, //rsa_alloc_wrap,
-        p11_rsa_free,
-#if defined(MBEDTLS_ECP_RESTARTABLE)
-rsa_rs_alloc,
-rsa_rs_free,
-#endif
-        NULL, //eckey_debug,        /* Compatible key structures */
-};
-#endif
-
 int p11_load_rsa(mbedtls_pk_context *pk, struct mp11_key_ctx_s *p11key, mp11_context *p11) {
     int rc;
     CK_BYTE ec_param[512];
@@ -75,7 +50,7 @@ int p11_load_rsa(mbedtls_pk_context *pk, struct mp11_key_ctx_s *p11key, mp11_con
             {CKA_MODULUS,         NULL, 0},
     };
 
-    pk->pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA);
+    pk->pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_RSA);
     pk->pk_ctx = p11key;
     p11key->ctx = p11;
 

--- a/src/p11/p11_mbedtls/p11_rsa.c
+++ b/src/p11/p11_mbedtls/p11_rsa.c
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <mbedtls/pk.h>
-#include <mbedtls/pk_internal.h>
+#include <mbedtls/error.h>
 #include "mbed_p11.h"
 #include <mbedtls/asn1write.h>
 #include <mbedtls/oid.h>
@@ -41,6 +41,7 @@ static void p11_rsa_free(void *ctx);
 
 static int get_md_prefix(mbedtls_md_type_t md, const char **prefix, size_t *len);
 
+#if 0
 const mbedtls_pk_info_t p11_rsa_info = {
         MBEDTLS_PK_RSA,
         "RSA",
@@ -63,6 +64,7 @@ rsa_rs_free,
 #endif
         NULL, //eckey_debug,        /* Compatible key structures */
 };
+#endif
 
 int p11_load_rsa(mbedtls_pk_context *pk, struct mp11_key_ctx_s *p11key, mp11_context *p11) {
     int rc;
@@ -73,7 +75,7 @@ int p11_load_rsa(mbedtls_pk_context *pk, struct mp11_key_ctx_s *p11key, mp11_con
             {CKA_MODULUS,         NULL, 0},
     };
 
-    pk->pk_info = &p11_rsa_info;
+    pk->pk_info = mbedtls_pk_info_from_type( MBEDTLS_PK_RSA);
     pk->pk_ctx = p11key;
     p11key->ctx = p11;
 
@@ -148,7 +150,7 @@ static int p11_rsa_sign(void *ctx, mbedtls_md_type_t md_alg,
     size_t oid_len = 0;
     rc = get_md_prefix(md_alg, &oid, &oid_len);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
     }
 
     CK_BYTE *msg = malloc(hash_len + oid_len);
@@ -157,12 +159,12 @@ static int p11_rsa_sign(void *ctx, mbedtls_md_type_t md_alg,
 
     rc = p11->funcs->C_SignInit(p11->session, &mech, p11key->priv_handle);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
     }
 
     rc = p11->funcs->C_Sign(p11->session, msg, hash_len + oid_len, rawsig, &rawsig_len);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
     }
 
     memcpy(sig, rawsig, rawsig_len);

--- a/src/p11/p11_mbedtls/p11_rsa.c
+++ b/src/p11/p11_mbedtls/p11_rsa.c
@@ -125,7 +125,7 @@ static int p11_rsa_sign(void *ctx, mbedtls_md_type_t md_alg,
     size_t oid_len = 0;
     rc = get_md_prefix(md_alg, &oid, &oid_len);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
     }
 
     CK_BYTE *msg = malloc(hash_len + oid_len);
@@ -134,12 +134,12 @@ static int p11_rsa_sign(void *ctx, mbedtls_md_type_t md_alg,
 
     rc = p11->funcs->C_SignInit(p11->session, &mech, p11key->priv_handle);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
     }
 
     rc = p11->funcs->C_Sign(p11->session, msg, hash_len + oid_len, rawsig, &rawsig_len);
     if (rc != CKR_OK) {
-        return MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
+        return MBEDTLS_ERR_ECP_HW_ACCEL_FAILED;
     }
 
     memcpy(sig, rawsig, rawsig_len);

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -422,7 +422,7 @@ static void send_pong(um_websocket_t *ws, const char* ping_data, int len) {
 }
 
 static void on_ws_close(um_websocket_t *ws) {
-    if (ws == NULL) return;
+    if (ws == NULL || ws->closed) return;
     if (ws->close_cb) {
         ws->close_cb((uv_handle_t *) ws);
     }
@@ -443,6 +443,7 @@ static void on_ws_close(um_websocket_t *ws) {
         ws->src->release(ws->src);
         ws->src = NULL;
     }
+    ws->closed = true;
 }
 static void ws_close_cb(uv_link_t *l) {
     um_websocket_t *ws = l->data;


### PR DESCRIPTION
New dependency is the branch for our ip-sans PR against 2.x - https://github.com/ARMmbed/mbedtls/pull/4494.

Note the 2.x PR is unlikely to be accepted by mbedtls due to concerns about new features in 2.x. Nonetheless we will keep the branch around and sync'ed until we are ready to take 3.x (and corresponding ip-sans PR is merged - https://github.com/ARMmbed/mbedtls/pull/2906)